### PR TITLE
Fix off-by-one error in scheduler use

### DIFF
--- a/src/unet/train.py
+++ b/src/unet/train.py
@@ -133,8 +133,6 @@ def train_unet(outdir):
         print("Assigning new tiles")
         train_loader.dataset.assign_new_tiles()
         cnn.train()
-        if scheduler:
-            scheduler.step()
         epoch_start = time.time()
 
         all_preds = []
@@ -165,6 +163,8 @@ def train_unet(outdir):
             global_step += 1
 
         duration = time.time() - epoch_start
+        if scheduler:
+            scheduler.step()
 
         print(f"\nTraining: epoch duration: {duration:.1f}")
         loss = loss_sum / len(all_true)


### PR DESCRIPTION
Apparently scheduler should be used only after at least a step of the optimizer:

```
UserWarning: Detected call of `lr_scheduler.step()` before `optimizer.step()`.  
In PyTorch 1.1.0 and later, you should call them in the opposite order: `optimizer.step()` before `lr_scheduler.step()
```